### PR TITLE
bowtie now catches pipe failures.

### DIFF
--- a/modules/bowtie/bowtie.nf
+++ b/modules/bowtie/bowtie.nf
@@ -19,7 +19,11 @@ process BOWTIE {
 
     script:
     """
-    zcat ${fq_read} | bowtie -p ${task.cpus} -q -a --best --strata --sam -v 3 -x ${params.bowtie_index} - 2> ${sampleID}.bowtie_${paired_read_num}.log | samtools view -bS - > ${sampleID}_mapped_${paired_read_num}.bam
+    set -o pipefail
+    
+    zcat ${fq_read} \\
+    | bowtie -p ${task.cpus} -q -a --best --strata --sam -v 3 -x ${params.bowtie_index} - 2> ${sampleID}.bowtie_${paired_read_num}.log \\
+    | samtools view -bS - > ${sampleID}_mapped_${paired_read_num}.bam
     """
     // NOTE: This is hard coded to .gz input files. 
 


### PR DESCRIPTION
If a corrupted FASTQ is input, the process creates corrupted output but does not record the error and cause Nextflow to realize the process has failed.  

This is because the error comes from the initial `zcat` and since it goes through a set of unix pipes, the exit code is not caught.  

This also changes the formatting of the `.command.sh` file so that each separate process in the pipe is on a separate line.